### PR TITLE
[IDS-1016] GO PATH

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/GhostGroup/datadog-fetch-hcl
+
+require (
+	github.com/cenkalti/backoff v2.1.0+incompatible
+	github.com/davecgh/go-spew v1.1.1
+	github.com/hashicorp/hcl v1.0.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/promiseofcake/datadog-fetch-hcl v0.0.0-20190104013347-f28f7f30a292
+	github.com/rodaine/hclencoder v0.0.0-20180926060551-0680c4321930
+	github.com/stretchr/testify v1.2.2
+	github.com/zorkian/go-datadog-api v0.0.0-20181127191241-1df5bda80d16
+)


### PR DESCRIPTION
this should allow you to compile datadog-fetch-hcl locally (because GOPATH)